### PR TITLE
Remove nexus plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,16 +160,6 @@
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.diffplug.spotless</groupId>
                 <artifactId>spotless-maven-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
Problem with the nexus plugin: We don't want to deploy all our artifacts, which works with the maven-deploy-plugin, (using the skip parameter), but does not with the nexus plugin. I'll try to get the non-nexus way to work with github actions, but may have fall back to using the nexus plugin after all.

See
* https://stackoverflow.com/questions/25305850/how-to-disable-nexus-staging-maven-plugin-in-sub-modules

* https://issues.sonatype.org/browse/NEXUS-9138?focusedCommentId=459861&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-459861