### PR TITLE
Fix MW/mW derivation bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Update QUDT to 2.1.20
+- Fix MW/mW derivation bug (#27) by adding missing QUDT triples manually (until the upstream fix is released)
+
 ## [2.0.1] - 2022-10-21
 
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <qudt.release.version>v2.1.19</qudt.release.version>
+        <qudt.release.version>v2.1.20</qudt.release.version>
     </properties>
 
     <scm>

--- a/qudtlib-data-gen/src/main/resources/additional-scalings.ttl
+++ b/qudtlib-data-gen/src/main/resources/additional-scalings.ttl
@@ -3,3 +3,13 @@
 
 unit:TON_Metric qudt:isScalingOf unit:GM.
 unit:TONNE qudt:isScalingOf unit:GM.
+
+# missing triples, will be added in upcoming QUDT releas
+unit:DeciTONNE qudt:conversionMultiplier 100.0 .
+unit:EarthMass qudt:conversionMultiplier 5972400000000000000000000.0 .
+unit:KiloTONNE qudt:conversionMultiplier 1000000.0 .
+unit:LunarMass qudt:conversionMultiplier 73460000000000000000000.0 .
+unit:MegaW qudt:conversionMultiplier 1000000.0 .
+unit:MilliW qudt:conversionMultiplier 0.001 .
+unit:NUM-PER-YR qudt:conversionMultiplier 0.00000003168808781402895023702689684893655 .
+

--- a/qudtlib-ingest-qudt/src/test/resources/query/missingConversionMultiplier.rq
+++ b/qudtlib-ingest-qudt/src/test/resources/query/missingConversionMultiplier.rq
@@ -1,0 +1,14 @@
+PREFIX qudt: <http://qudt.org/schema/qudt/>
+PREFIX qk: <http://qudt.org/vocab/quantitykind/>
+
+SELECT ?u  where
+{
+    ?u a qudt:Unit ;
+    FILTER NOT EXISTS {
+        ?u qudt:conversionMultiplier ?multiplier
+    }
+    FILTER NOT EXISTS {
+        ?u qudt:hasQuantityKind qk:Currency
+    }
+}
+order by str(?u)

--- a/qudtlib-test/src/test/java/io/github/qudtlib/DerivedUnitTests.java
+++ b/qudtlib-test/src/test/java/io/github/qudtlib/DerivedUnitTests.java
@@ -519,4 +519,14 @@ public class DerivedUnitTests {
         MatcherAssert.assertThat(base.getValue(), Matchers.comparesEqualTo(BigDecimal.ONE));
         assertEquals(Qudt.Units.M, base.getKey());
     }
+
+    @Test
+    public void testScaleWatt() {
+        List<FactorUnit> wattFactors = Qudt.simplifyFactorUnits(Qudt.Units.W.getFactorUnits());
+        Set<Unit> units =
+                Qudt.derivedUnitsFromFactorUnits(DerivedUnitSearchMode.EXACT, wattFactors);
+        assertEquals(units.size(), 2);
+        assertTrue(units.contains(Qudt.Units.W));
+        assertTrue(units.contains(Qudt.Units.J__PER__SEC));
+    }
 }


### PR DESCRIPTION
Fixes #27.

The cause were missing qudt:conversionMultiplier triples for unit:MW and unit:mW. The upstream fix is merged and will have an effect for us when qudt is released and we upgrade. Meanwhile, the triples are added.

We also upgrade to qudt v2.1.20, which causes a minor release for us.