### PR TITLE
Bump QUDT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated QUDT to [v2.1.25](https://github.com/qudt/qudt-public-repo/releases/tag/v2.1.25)
 
+### Added
+
+- Add qudt namespace to Qudt.NAMESPACES
+
 ## [4.1.0] - 2023-02-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated QUDT to [v2.1.25](https://github.com/qudt/qudt-public-repo/releases/tag/v2.1.25)
+
 ## [4.1.0] - 2023-02-13
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <qudt.release.version>v2.1.24</qudt.release.version>
+        <qudt.release.version>v2.1.25</qudt.release.version>
     </properties>
 
     <scm>

--- a/qudtlib-data-gen/src/main/resources/triples-to-add-to-units.ttl
+++ b/qudtlib-data-gen/src/main/resources/triples-to-add-to-units.ttl
@@ -12,6 +12,8 @@ unit:TON_Metric qudt:isScalingOf unit:GM .
 unit:TONNE qudt:isScalingOf unit:GM .
 unit:MIN qudt:isScalingOf unit:SEC .
 unit:HR qudt:isScalingOf unit:SEC .
+unit:HR_Sidereal qudt:isScalingOf unit:SEC .
+unit:MIN_Sidereal qudt:isScalingOf unit:SEC .
 unit:DAY qudt:isScalingOf unit:SEC .
 unit:DAY_Sidereal qudt:isScalingOf unit:SEC .
 unit:WK qudt:isScalingOf unit:SEC .

--- a/qudtlib-model/src/main/java/io/github/qudtlib/model/QudtNamespaces.java
+++ b/qudtlib-model/src/main/java/io/github/qudtlib/model/QudtNamespaces.java
@@ -7,4 +7,5 @@ public class QudtNamespaces {
     public static final Namespace prefix = new Namespace("http://qudt.org/vocab/prefix/", "prefix");
     public static final Namespace systemOfUnits =
             new Namespace("http://qudt.org/vocab/sou/", "sou");
+    public static final Namespace qudt = new Namespace("http://qudt.org/schema/qudt/", "qudt");
 }

--- a/qudtlib-test/src/test/java/io/github/qudtlib/SystemOfUnitsTests.java
+++ b/qudtlib-test/src/test/java/io/github/qudtlib/SystemOfUnitsTests.java
@@ -80,6 +80,38 @@ public class SystemOfUnitsTests {
 
     @Test
     @Disabled
+    public void testGenerateSystemOfUnitTriples() {
+        System.out.println(
+                String.format(
+                        "@prefix %s: <%s> .",
+                        Qudt.NAMESPACES.unit.getAbbreviationPrefix(),
+                        Qudt.NAMESPACES.unit.getBaseIri()));
+        System.out.println(
+                String.format(
+                        "@prefix %s: <%s> .",
+                        Qudt.NAMESPACES.systemOfUnits.getAbbreviationPrefix(),
+                        Qudt.NAMESPACES.systemOfUnits.getBaseIri()));
+        System.out.println(
+                String.format(
+                        "@prefix %s: <%s> .",
+                        Qudt.NAMESPACES.qudt.getAbbreviationPrefix(),
+                        Qudt.NAMESPACES.qudt.getBaseIri()));
+        for (SystemOfUnits sou : Qudt.allSystemsOfUnits()) {
+            for (Unit unit : Qudt.allUnits()) {
+                if (sou.allowsUnit(unit)) {
+                    System.out.println(
+                            String.format(
+                                    "%s %s %s .",
+                                    Qudt.NAMESPACES.unit.abbreviate(unit.getIri()),
+                                    "qudt:isUnitOfSystem",
+                                    Qudt.NAMESPACES.systemOfUnits.abbreviate(sou.getIri())));
+                }
+            }
+        }
+    }
+
+    @Test
+    @Disabled
     public void testImperialRelatedUnits() {
         Set<Unit> explicitlyAssociated =
                 Qudt.getUnitsMap().values().stream()
@@ -168,6 +200,10 @@ public class SystemOfUnitsTests {
                         .filter(u -> SystemsOfUnits.SI.allowsUnit(u))
                         .map(Unit::getIri)
                         .collect(Collectors.toSet());
+        // no longer true in 2.1.25
+        // assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A_Ab")));
+        // assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A_Ab-CentiM2")));
+        // assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A_Ab-PER-CentiM2")));
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A")));
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A-HR")));
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A-M2")));
@@ -186,9 +222,6 @@ public class SystemOfUnitsTests {
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:AT")));
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:AT-PER-M")));
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:AU")));
-        assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A_Ab")));
-        assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A_Ab-CentiM2")));
-        assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:A_Ab-PER-CentiM2")));
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:AttoC")));
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:AttoFARAD")));
         assertTrue(siUnitIris.contains(Qudt.NAMESPACES.unit.expand("unit:AttoJ")));


### PR DESCRIPTION
- bump to 2.1.25
- adapt to removal of `qudt:isScalingOf`
- add namespace for qudt