### PR TITLE
Fix offsetDifference and scaleDifference

### DIFF
--- a/qudtlib-main/src/main/java/io/github/qudtlib/Qudt.java
+++ b/qudtlib-main/src/main/java/io/github/qudtlib/Qudt.java
@@ -1078,17 +1078,17 @@ public class Qudt {
     }
 
     private static double scaleDifference(Unit u1, Unit u2) {
-        BigDecimal u1Log10 = Log10BigDecimal.log10(u1.getConversionMultiplier().get());
-        BigDecimal u2Log10 = Log10BigDecimal.log10(u2.getConversionMultiplier().get());
+        BigDecimal u1Log10 = Log10BigDecimal.log10(u1.getConversionMultiplier().orElse(BigDecimal.ONE));
+        BigDecimal u2Log10 = Log10BigDecimal.log10(u2.getConversionMultiplier().orElse(BigDecimal.ONE));
         return u1Log10.doubleValue() - u2Log10.doubleValue();
     }
 
     private static double offsetDifference(Unit u1, Unit u2) {
-        BigDecimal u1Log10 = u1.getConversionOffset().get().abs();
+        BigDecimal u1Log10 = u1.getConversionOffset().orElse(BigDecimal.ZERO).abs();
         if (u1Log10.compareTo(BigDecimal.ZERO) > 0) {
             u1Log10 = Log10BigDecimal.log10(u1Log10);
         }
-        BigDecimal u2Log10 = u2.getConversionOffset().get().abs();
+        BigDecimal u2Log10 = u2.getConversionOffset().orElse(BigDecimal.ZERO).abs();
         if (u2Log10.compareTo(BigDecimal.ZERO) > 0) {
             u2Log10 = Log10BigDecimal.log10(u2Log10);
         }

--- a/qudtlib-test/src/test/java/io/github/qudtlib/QudtTests.java
+++ b/qudtlib-test/src/test/java/io/github/qudtlib/QudtTests.java
@@ -887,5 +887,6 @@ public class QudtTests {
     public void nullOffsetDifference() {
         Optional<Unit> unit = Qudt.correspondingUnitInSystem(IN, Qudt.SystemsOfUnits.SI);
         Assertions.assertTrue(unit.isPresent());
+        Assertions.assertEquals(Qudt.Units.CentiM, unit.get());
     }
 }

--- a/qudtlib-test/src/test/java/io/github/qudtlib/QudtTests.java
+++ b/qudtlib-test/src/test/java/io/github/qudtlib/QudtTests.java
@@ -10,6 +10,7 @@ import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -880,5 +881,11 @@ public class QudtTests {
     public void testUcumCode() {
         Assertions.assertEquals("t.m-3", Qudt.Units.TONNE__PER__M3.getUcumCode().get());
         Assertions.assertEquals("J.kg-1.K-1", J__PER__KiloGM__K.getUcumCode().get());
+    }
+
+    @Test
+    public void nullOffsetDifference() {
+        Optional<Unit> unit = Qudt.correspondingUnitInSystem(IN, Qudt.SystemsOfUnits.SI);
+        Assertions.assertTrue(unit.isPresent());
     }
 }


### PR DESCRIPTION
Offset difference and scale difference no longer throw exceptions when the provided Units do not have explicit conversion values

Instead, the unchecked get() are replaced by orElse() calls, providing the correct default values.

This fixes a bug when, for example, trying to find the offsetDifference between Inch and Meter, which do not bother to specify their 0 offsets explicitly.