### PR TITLE
Bump QUDT version to 3.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump QUDT version to [3.1.10](https://github.com/qudt/qudt-public-repo/releases/tag/v3.1.10)
+
 ## [7.2.0] - 2026-02-11
 
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <qudt.release.version>3.1.5</qudt.release.version>
+        <qudt.release.version>3.1.10</qudt.release.version>
         <spotless.format.version>1.33.0</spotless.format.version>
     </properties>
 

--- a/qudtlib-test/src/test/java/io/github/qudtlib/FactorUnitsTests.java
+++ b/qudtlib-test/src/test/java/io/github/qudtlib/FactorUnitsTests.java
@@ -463,10 +463,10 @@ public class FactorUnitsTests {
                     String.format(
                             "%s.getConversionMultiplierOpt() is expected to return a value",
                             unit.getIriAbbreviated()));
-            assertEquals(
+            assertThat(
                     unit.getFactorUnits().getConversionMultiplierWithFallbackOne(),
-                    result.get(),
-                    String.format("Wrong result for %s", unit.getIriAbbreviated()));
+                    is(closeTo(result.get(), new BigDecimal("0.00001"))));
+
         } else {
             assertTrue(
                     result.isEmpty(),


### PR DESCRIPTION
.. and fix unit test failures arising from some units having a conversion multiplier of 0.